### PR TITLE
Fix #13 - use version(TardyTest) instead of version(unittest)

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -21,7 +21,7 @@ configuration "unittest" {
 
     dependency "unit-threaded" version="*"
 
-    versions "unitUnthreaded"
+    versions "unitUnthreaded" "TardyTest"
 }
 
 
@@ -39,5 +39,5 @@ configuration "asan" {
 
     dependency "unit-threaded" version="*"
 
-    versions "unitUnthreaded" "nodip1008"
+    versions "unitUnthreaded" "nodip1008" "TardyTest"
 }

--- a/source/tardy/package.d
+++ b/source/tardy/package.d
@@ -4,7 +4,7 @@ public import tardy.poly;
 public import tardy.allocators;
 
 
-version(unittest):
+version(TardyTest):
 
 import tardy;
 


### PR DESCRIPTION
Because `version(unittest)` is broken.